### PR TITLE
Fixed issues found while testing on Ubuntu Trusty 3.13 64 bits

### DIFF
--- a/bin/cito-plugin-server.sh
+++ b/bin/cito-plugin-server.sh
@@ -24,8 +24,18 @@ source /opt/virtualenvs/citopluginvenv/bin/activate
 
 test -d $LOGDIR || mkdir -p $LOGDIR
 
-python manage.py run_gunicorn \
-	--workers $NUM_WORKERS \
-	--user=$USER --group=$GROUP \
-	--log-level=debug --log-file=$LOGFILE 2>>$LOGFILE --bind $BIND_IP
+#This was the original command to start the app
+#python manage.py run_gunicorn \
+#        --workers $NUM_WORKERS \
+#        --user=$USER --group=$GROUP \
+#        --log-level=debug --log-file=$LOGFILE 2>>$LOGFILE --bind $BIND_IP
 
+# This is the command for starting the app in dev mode
+#python manage.py runserver $BIND_IP
+
+# This is the workaround command for starting the app if run_gunicorn fails
+gunicorn --workers=$NUM_WORKERS \
+         --user $USER \
+         --group $GROUP \
+         --log-level=debug --log-file=$LOGFILE 2>>$LOGFILE --bind $BIND_IP \
+         cito_plugin_server.wsgi

--- a/bin/upstart/configure-upstart.sh
+++ b/bin/upstart/configure-upstart.sh
@@ -11,5 +11,5 @@ fi
 
 echo "Configuring cito-plugin-server.."
 ln -sf /lib/init/upstart-job /etc/init.d/cito-plugin-server
-cp /opt/cito/bin/upstart/cito-plugin-server.conf /etc/init/
+cp /opt/cito_plugin_server/bin/upstart/cito-plugin-server.conf /etc/init/
 /usr/sbin/update-rc.d cito-plugin-server defaults

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ anyjson==0.3.3
 argparse==1.2.1
 billiard==2.7.3.31
 coverage==3.5.2
-distribute==0.6.45
+distribute==0.7.3
 django-tastypie==0.9.15
 django-nose==1.2
 factory-boy==2.3.1


### PR DESCRIPTION
* Path in upstart script is wrong, it says "_cito_" but should be "_cito_plugin_server_": _cp /opt/**cito**/bin/upstart/cito-plugin-server.conf /etc/init/_

* distribute package _0.6.45_ version failing to install even after upgrading setuptools (error: "_NameError: name 'sys_platform' is not defined_"), however modifying requirements file to instead use version _0.7.3_ solved the issue.

* _cito-plugin-server.sh script_ is not launching the app, upon debugging found that "_python manage.py run_gunicorn.._" command is failing with "_Unknown command: 'run_gunicorn'_" error everytime even after confirming "_gunicorn_" package is there in "_INSTALLED_APPS_" in base.py. Able to launch app succesfully in development mode by running : "_python manage.py runserver 0.0.0.0:9000_". Finally, found a workaround by editing the startup script file to launch the app like:

```
gunicorn --workers=$NUM_WORKERS \
         --user $USER \
         --group $GROUP \
         --log-level=debug --log-file=$LOGFILE 2>>$LOGFILE --bind $BIND_IP \
         cito_plugin_server.wsgi

```